### PR TITLE
Target v2 of Modrinth publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           changelog: ${{ steps.changelog.outputs.changelog }}
           version:  ${{ needs.getinfo.outputs.tag }}
           token: ${{ secrets.MODRINTH_TOKEN }}
-          game-versions: ${{ matrix.version }}
+          game-versions: ${{ matrix.version }}.x
           channel: ${{ steps.release-type.outputs.type }}
           files: JqshuvPack-${{ matrix.version }}.X.zip
           loaders: minecraft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           esac
           echo "::set-output name=type::$rel_type"
       - name: "🧬 Create release"
-        uses: cloudnode-pro/modrinth-publish@2.0.0
+        uses: cloudnode-pro/modrinth-publish@v2
         with:
           project: r4SmPOJL
           name: ${{ needs.getinfo.outputs.tag }}


### PR DESCRIPTION
Hi! Thanks for using modrinth-publish. To benefit from backwards-compatible SemVer patch & minor releases, we now recommend targeting `v2`.

Alternatively, you can set up [`.github/dependabot.yaml`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) to open a pull request to update to specific versions as they are released.

```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
```

I also added `.x` after the game version which will be expanded by the action into the full range of patch versions.